### PR TITLE
V0.1.13 2024 sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 
 ARG VERSION=0.1.13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /tmp/ \
     && wget https://github.com/BitgesellOfficial/bitgesell/releases/download/${VERSION}/bitgesell_${VERSION}_amd64.deb \
     && wget http://ports.ubuntu.com/pool/main/p/perl/perl-modules-5.34_5.34.0-3ubuntu1.3_all.deb \
     && apt-get install libsqlite3-dev -y \
-    && dpkg -i perl-modules-5.30_5.30.0-9build1_all.deb \
+    && dpkg -i perl-modules-5.34_5.34.0-3ubuntu1.3_all.deb \
     && dpkg -i bitgesell_${VERSION}_amd64.deb \
     && apt-get install -y -f \
     && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04 as builder
 
-ARG VERSION=0.1.12
+ARG VERSION=0.1.13
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update \
 
 RUN cd /tmp/ \
     && wget https://github.com/BitgesellOfficial/bitgesell/releases/download/${VERSION}/bitgesell_${VERSION}_amd64.deb \
-    && wget http://ports.ubuntu.com/pool/main/p/perl/perl-modules-5.30_5.30.0-9build1_all.deb \
+    && wget http://ports.ubuntu.com/pool/main/p/perl/perl-modules-5.34_5.34.0-3ubuntu1.3_all.deb \
     && apt-get install libsqlite3-dev -y \
     && dpkg -i perl-modules-5.30_5.30.0-9build1_all.deb \
     && dpkg -i bitgesell_${VERSION}_amd64.deb \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `bgld-docker` changelog 
 
-## `v0.1.11` `BitcoinCore` sync - 17/06/2024
+## `v0.1.13` `BitcoinCore` sync - 27/08/2024
+
+Changes:
+
+- Synced with Bitcoin core upto June, 2023 - See [`v0.1.13` release notes](https://github.com/BitgesellOfficial/bitgesell/releases/tag/0.1.13)
+
+## `v0.1.12` `BitcoinCore` sync - 17/06/2024
 
 Changes:
 


### PR DESCRIPTION
# Summary
1. Update to use Bitgesell core synced with Bitcoin Core up to 2024
2. Update base image to 22.04(Jammy Jellyfish)
3. Update lib-perl-module depended on by Bitgesell